### PR TITLE
fixed as_model subclass check in board.get_items_by_column_values()

### DIFF
--- a/moncli/entities/board.py
+++ b/moncli/entities/board.py
@@ -1192,7 +1192,7 @@ class Board(_Board):
         items = [en.Item(creds=self.__creds, **item_data) for item_data in items_data] 
         if not as_model:
             return items
-        if not issubclass(type(as_model), MondayModel):
+        if not issubclass(as_model, MondayModel):
             raise BoardError(
                 'invalid_as_model_parameter',
                 self.id,


### PR DESCRIPTION
previously, 'as_model' param was being checked that it's type is a sublclass of MondayModel. now it checks that the object itself is a subclass